### PR TITLE
Fix/name var and schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0, <= 1.5.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | ~> 0.11.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.96.0 |
 
@@ -30,7 +30,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | (Required) The project ID or project name. | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The name of the build definition. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the build definition. | `string` | n/a | yes |
 | <a name="input_path"></a> [path](#input\_path) | The folder path of the build definition. | `string` | `null` | no |
 | <a name="input_agent_pool_name"></a> [agent\_pool\_name](#input\_agent\_pool\_name) | The agent pool that should execute the build. Defaults to Azure Pipelines. | `string` | `"Azure Pipelines"` | no |
 | <a name="input_ci_trigger"></a> [ci\_trigger](#input\_ci\_trigger) | The repository block as documented below. | <pre>object({<br>    use_yaml = optional(bool)<br>    override = optional(object({<br>      batch = optional(bool)<br>      branch_filter = optional(object({<br>        include = optional(list(string))<br>        exclude = optional(list(string))<br>      }))<br>      path_filter = optional(object({<br>        include = optional(list(string))<br>        exclude = optional(list(string))<br>      }))<br>      max_concurrent_builds_per_branch = number<br>      polling_interval                 = number<br>      polling_job_id                   = string<br>    }))<br>  })</pre> | <pre>{<br>  "use_yaml": false<br>}</pre> | no |
@@ -38,8 +38,8 @@ No modules.
 | <a name="input_variable_groups"></a> [variable\_groups](#input\_variable\_groups) | A list of variable group IDs (integers) to link to the build definition. Defaults to {}. | `list(number)` | `null` | no |
 | <a name="input_features"></a> [features](#input\_features) | A list of variable group IDs (integers) to link to the build definition. Defaults to {}. | <pre>object({<br>    skip_first_run = optional(bool)<br>  })</pre> | `{}` | no |
 | <a name="input_queue_status"></a> [queue\_status](#input\_queue\_status) | The queue status of the build definition. Valid values: enabled or paused or disabled. Defaults to enabled. | `string` | `"enabled"` | no |
-| <a name="input_schedules"></a> [schedules](#input\_schedules) | The repository block as documented below. | <pre>object({<br>    days_to_build              = list(string)<br>    schedule_only_with_changes = optional(bool)<br>    start_hours                = optional(string)<br>    start_minutes              = optional(string)<br>    time_zone                  = optional(string)<br>    branch_filter = optional(object({<br>      include = optional(list(string))<br>      exclude = optional(list(string))<br>    }))<br>  })</pre> | n/a | yes |
-| <a name="input_repository"></a> [repository](#input\_repository) | The repository block as documented below. | <pre>object({<br>    branch_name           = string<br>    repo_id               = string<br>    repo_type             = string<br>    service_connection_id = string<br>    yml_path              = optional(string)<br>    github_enterprise_url = optional(string)<br>    report_build_status   = optional(bool)<br>  })</pre> | n/a | yes |
+| <a name="input_schedules"></a> [schedules](#input\_schedules) | The schedules block as documented below. | <pre>object({<br>    days_to_build              = list(string)<br>    schedule_only_with_changes = optional(bool)<br>    start_hours                = optional(string)<br>    start_minutes              = optional(string)<br>    time_zone                  = optional(string)<br>    branch_filter = optional(object({<br>      include = optional(list(string))<br>      exclude = optional(list(string))<br>    }))<br>  })</pre> | `null` | no |
+| <a name="input_repository"></a> [repository](#input\_repository) | The repository block as documented below. | <pre>object({<br>    branch_name           = string<br>    repo_id               = string<br>    repo_type             = string<br>    service_connection_id = optional(string)<br>    yml_path              = optional(string)<br>    github_enterprise_url = optional(string)<br>    report_build_status   = optional(bool)<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,6 +13,7 @@
 module "pipeline" {
   source = "../.."
 
+  name       = var.name
   project_id = var.project_id
   repository = var.repository
   schedules  = var.schedules

--- a/examples/complete/test.tfvars
+++ b/examples/complete/test.tfvars
@@ -12,6 +12,8 @@
 
 project_id = "<PROJECT_ID>"
 
+name = "demo-pipeline"
+
 repository = {
   repo_type             = "GitHub"
   repo_id               = "launchbynttdata/demo-azure-resource-group"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -15,13 +15,18 @@ variable "project_id" {
   type        = string
 }
 
+variable "name" {
+  description = "The name of the build definition."
+  type        = string
+}
+
 variable "repository" {
   description = "The repository block as documented below."
   type = object({
     branch_name           = string
     repo_id               = string
     repo_type             = string
-    service_connection_id = string
+    service_connection_id = optional(string)
     yml_path              = optional(string)
     github_enterprise_url = optional(string)
     report_build_status   = optional(bool)
@@ -41,4 +46,5 @@ variable "schedules" {
       exclude = optional(list(string))
     }))
   })
+  default = null
 }

--- a/main.tf
+++ b/main.tf
@@ -94,18 +94,22 @@ resource "azuredevops_build_definition" "build_definition" {
     report_build_status   = var.repository.report_build_status
   }
 
-  schedules {
-    dynamic "branch_filter" {
-      for_each = var.schedules.branch_filter != null ? [var.schedules.branch_filter] : []
-      content {
-        include = var.schedules.branch_filter.include
-        exclude = var.schedules.branch_filter.exclude
+  dynamic "schedules" {
+    for_each = var.schedules != null ? ["schedules"] : []
+
+    content {
+      dynamic "branch_filter" {
+        for_each = var.schedules.branch_filter != null ? [var.schedules.branch_filter] : []
+        content {
+          include = var.schedules.branch_filter.include
+          exclude = var.schedules.branch_filter.exclude
+        }
       }
+      days_to_build              = var.schedules.days_to_build
+      schedule_only_with_changes = var.schedules.schedule_only_with_changes
+      start_hours                = var.schedules.start_hours
+      start_minutes              = var.schedules.start_minutes
+      time_zone                  = var.schedules.time_zone
     }
-    days_to_build              = var.schedules.days_to_build
-    schedule_only_with_changes = var.schedules.schedule_only_with_changes
-    start_hours                = var.schedules.start_hours
-    start_minutes              = var.schedules.start_minutes
-    time_zone                  = var.schedules.time_zone
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,6 @@ variable "project_id" {
 variable "name" {
   description = "The name of the build definition."
   type        = string
-  default     = null
 }
 
 variable "path" {
@@ -108,7 +107,7 @@ variable "queue_status" {
 }
 
 variable "schedules" {
-  description = "The repository block as documented below."
+  description = "The schedules block as documented below."
   type = object({
     days_to_build              = list(string)
     schedule_only_with_changes = optional(bool)
@@ -120,6 +119,7 @@ variable "schedules" {
       exclude = optional(list(string))
     }))
   })
+  default = null
 }
 
 variable "repository" {
@@ -128,7 +128,7 @@ variable "repository" {
     branch_name           = string
     repo_id               = string
     repo_type             = string
-    service_connection_id = string
+    service_connection_id = optional(string)
     yml_path              = optional(string)
     github_enterprise_url = optional(string)
     report_build_status   = optional(bool)

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 terraform {
-  required_version = ">= 1.5.0, <= 1.5.5"
+  required_version = "~> 1.0"
 
   required_providers {
     azuredevops = {


### PR DESCRIPTION
- makes the `name` variable required, currently fails when not supplied

- makes the `schedules` variable optional
  - schedules can alternatively be defined in the pipeline yaml if they are not defined here
  
- `service_connection_id` no longer required when defining repository, its only necessary for github repos