### PR TITLE
Fix/not idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ No modules.
 |------|------|
 | [azuredevops_build_definition.build_definition](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
 | [azuredevops_git_repository.repo](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/git_repository) | data source |
+| [azuredevops_project.project](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [azuredevops_build_definition.build_definition](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) | resource |
+| [azuredevops_git_repository.repo](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/git_repository) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+data "azuredevops_git_repository" "repo" {
+  project_id = var.project_id
+  name       = var.repository.repo_id
+}
+
 resource "azuredevops_build_definition" "build_definition" {
   project_id      = var.project_id
   name            = var.name
@@ -86,7 +91,7 @@ resource "azuredevops_build_definition" "build_definition" {
 
   repository {
     branch_name           = var.repository.branch_name
-    repo_id               = var.repository.repo_id
+    repo_id               = data.azuredevops_git_repository.repo.id
     repo_type             = var.repository.repo_type
     service_connection_id = var.repository.service_connection_id
     yml_path              = var.repository.yml_path

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+data "azuredevops_project" "project" {
+  count = (var.repository.repo_type == "TfsGit") ? 1 : 0
+
+  name = var.project_id
+}
+
 data "azuredevops_git_repository" "repo" {
-  project_id = var.project_id
+  count = (var.repository.repo_type == "TfsGit") ? 1 : 0
+
+  project_id = data.azuredevops_project.project[0].id
   name       = var.repository.repo_id
 }
 
@@ -91,7 +99,7 @@ resource "azuredevops_build_definition" "build_definition" {
 
   repository {
     branch_name           = var.repository.branch_name
-    repo_id               = data.azuredevops_git_repository.repo.id
+    repo_id               = var.repository.repo_type == "TfsGit" ? data.azuredevops_git_repository.repo[0].id : var.repository.repo_id
     repo_type             = var.repository.repo_type
     service_connection_id = var.repository.service_connection_id
     yml_path              = var.repository.yml_path


### PR DESCRIPTION
when using azure repos, it changes the `repo_id` from the name to a guid behind the scenes

here we change the behavior to use the guid when deploying